### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ freqs_for_each_token = torch.outer(torch.arange(17), freqs)
 freqs_cis = torch.polar(torch.ones_like(freqs_for_each_token), freqs_for_each_token)
 freqs_cis.shape
 
-# viewing tjhe third row of freqs_cis
+# viewing the third row of freqs_cis
 value = freqs_cis[3]
 plt.figure()
 for i, element in enumerate(value[:17]):


### PR DESCRIPTION
Fix typo in readme.

Also a quick note that the comment mentions the third row, but seems to access the fourth value assuming tensors are 0-indexed.